### PR TITLE
Corrections et renommages scripts ETL

### DIFF
--- a/Scripts_ETL/scripts/config.txt
+++ b/Scripts_ETL/scripts/config.txt
@@ -1,6 +1,6 @@
 [Paths]
-chemin_entree = /usr/src/app/datalake/
-chemin_sortie = /usr/src/app/warehouse_csv/
+datalake = /usr/src/app/datalake/
+warehouse_csv = /usr/src/app/warehouse_csv/
 
 [SQL]
 host=warehouse_db

--- a/Scripts_ETL/scripts/etl-datalake-ref.py
+++ b/Scripts_ETL/scripts/etl-datalake-ref.py
@@ -1,0 +1,106 @@
+import pandas as pd
+import zipfile
+import os
+import configparser
+
+# Récupération des variables placées sur config.txt
+config = configparser.ConfigParser()
+config.read('/usr/src/app/scripts/config.txt')
+datalake = config.get('Paths', 'datalake')
+warehouse_csv = config.get('Paths', 'warehouse_csv')
+
+
+print("\n *** Chargement des fichiers de référence du Datalake vers Warehouse_CSV *** \n")
+
+
+
+# Traitement vers codes_region.csv
+# Chargement des fichiers depuis Datalake
+df_in_donnees_regions = pd.read_csv(datalake + 'donnees_regions.csv', usecols=['CODREG','REG','PTOT'], sep=';')
+df_in_regions_zones_scolaires = pd.read_csv(datalake + 'regions-zones-scolaires.csv', usecols=['CODREG','ZONE'], sep=';')
+# Fusion des fichiers via variable CODREG
+df_out_codes_region = pd.merge(df_in_donnees_regions, df_in_regions_zones_scolaires, on='CODREG')
+# Renommmage des colonnes
+df_out_codes_region.columns = ['ID_code_region', 'Nom_region', 'Population_region', 'Zone_vacances']
+# Enregistrement du fichier dans Warehouse_CSV
+df_out_codes_region.to_csv(warehouse_csv + 'codes_region.csv', sep=';', index=False)
+# Confirmation de traitement
+print("Traitement vers codes_region : OK")
+
+
+
+# Traitement vers codes_departement.csv
+# Chargement des fichiers depuis Datalake
+df_in_donnees_departements = pd.read_csv(datalake + 'donnees_departements.csv', usecols=['CODREG','CODDEP','DEP','PTOT'], sep=';')
+# Renommmage des colonnes
+df_out_codes_departements = df_in_donnees_departements
+df_out_codes_departements.columns = ['Code_region', 'ID_code_departement', 'Nom_departement', 'Population_departement']
+# Réorganiser les colonnes dans le DataFrame
+df_out_codes_departements = df_out_codes_departements.reindex(columns=['ID_code_departement', 'Nom_departement', 'Population_departement', 'Code_region'])
+# Enregistrement du fichier dans Warehouse_CSV
+df_out_codes_departements.to_csv(warehouse_csv + 'codes_departement.csv', sep=';', index=False)
+# Confirmation de traitement
+print("Traitement vers codes_departement : OK")
+
+
+
+# Traitement vers codes_commune.csv
+# Chargement des fichiers depuis Datalake
+df_in_donnees_communes = pd.read_csv(datalake + 'donnees_communes.csv', usecols=['CODDEP','Code commune','COM','PTOT'], sep=';')
+# Renommmage des colonnes
+df_out_codes_commune = df_in_donnees_communes
+df_out_codes_commune.columns = ['Code_departement', 'ID_code_commune', 'Nom_commune', 'Population_commune']
+# Réorganiser les colonnes dans le DataFrame
+df_out_codes_commune = df_out_codes_commune.reindex(columns=['ID_code_commune', 'Nom_commune', 'Population_commune', 'Code_departement'])
+# Enregistrement du fichier dans Warehouse_CSV
+df_out_codes_commune.to_csv(warehouse_csv + 'codes_commune.csv', sep=';', index=False)
+# Confirmation de traitement
+print("Traitement vers codes_commune : OK")
+
+
+
+# Traitement vers calendrier_vacances_scolaires.csv
+# Chargement des fichiers depuis Datalake
+df_in_calendrier_vacances = pd.read_excel(datalake + 'calendrier-vacances.xlsx', "Feuil1", index_col=None, na_values=["NA"])
+df_out_calendrier_vacances = df_in_calendrier_vacances
+# Ajout colonne Semaine ou Week-end
+df_out_calendrier_vacances.loc[(df_out_calendrier_vacances.Jour == "Samedi") | (df_out_calendrier_vacances.Jour == "Dimanche"), "Semaine"] = "Week-end"
+df_out_calendrier_vacances.loc[~((df_out_calendrier_vacances.Jour == "Samedi") | (df_out_calendrier_vacances.Jour == "Dimanche")), "Semaine"] = "Semaine"
+# Enregistrement du fichier dans Warehouse_CSV
+df_out_calendrier_vacances.to_csv(warehouse_csv + 'calendrier_vacances_scolaires.csv', sep=';', index=False)
+# Confirmation de traitement
+print("Traitement vers calendrier_vacances_scolaires : OK")
+
+
+
+# Traitement vers surf_logement_commune.csv et type_logement_commune.csv
+# Décompression de la source
+with zipfile.ZipFile(datalake + 'RP2019_LOGEMT_csv.zip', 'r') as zip_ref:
+    zip_ref.extractall(datalake + 'tmp')
+# Chargement de la source dans un dataframe
+df_in_donnees_logements = pd.read_csv(datalake + 'tmp/FD_LOGEMT_2019.csv', usecols=['COMMUNE','SURF','TYPL'], sep=';', dtype={'COMMUNE': str})
+# Aggrégation par surface de logement
+df_out_surf_logement = pd.crosstab(index=df_in_donnees_logements['COMMUNE'], columns=df_in_donnees_logements['SURF'], rownames=['COMMUNE'])
+df_out_surf_logement = df_out_surf_logement.reset_index()
+# Aggrégation par type de logement
+df_out_type_logement = pd.crosstab(index=df_in_donnees_logements['COMMUNE'], columns=df_in_donnees_logements['TYPL'], rownames=['COMMUNE'])
+df_out_type_logement = df_out_type_logement.reset_index()
+df_out_type_logement["type_autres"] = df_out_type_logement[[3, 4, 5, 6]].sum(axis=1)
+df_out_type_logement = df_out_type_logement.drop([3, 4, 5, 6], axis=1)
+# Renommage des colonnes
+df_out_surf_logement.columns = ['Code_commune','surf_moins_30','surf_30_40','surf_40_60','surf_60_80','surf_80_100','surf_100_120','surf_plus_120','surf_hors_res_principale']
+df_out_type_logement.columns = ['Code_commune','type_maison','type_appartement','type_autres']
+# Enregistrement des fichiers dans Warehouse_CSV
+df_out_surf_logement.to_csv(warehouse_csv + 'surf_logement_commune.csv', sep=';', index=False)
+df_out_type_logement.to_csv(warehouse_csv + 'type_logement_commune.csv', sep=';', index=False)
+# Suppression du dossier temporaire
+dossier_a_supprimer = datalake + "tmp"
+os.system(f"sudo chmod -R 777 {dossier_a_supprimer}")
+os.system(f"rm -rf {dossier_a_supprimer}")
+# Confirmation de traitement
+print("Traitement vers surf_logement_commune.csv et type_logement_commune.csv : OK")
+
+
+
+# Confirmation de fin de tous les traitements
+print("\n *** Fin du chargement des fichiers du Datalake vers Warehouse_CSV *** \n")

--- a/Scripts_ETL/scripts/etl-datalake-update.py
+++ b/Scripts_ETL/scripts/etl-datalake-update.py
@@ -1,0 +1,98 @@
+import pandas as pd
+import configparser
+
+# Récupération des variables placées sur config.txt
+config = configparser.ConfigParser()
+config.read('/usr/src/app/scripts/config.txt')
+datalake = config.get('Paths', 'datalake')
+warehouse_csv = config.get('Paths', 'warehouse_csv')
+
+print("\n *** Chargement des fichiers de consommation, production et import/export du Datalake vers Warehouse_CSV *** \n")
+
+
+
+# Traitement vers consommation_quotidienne_brute_regionale.csv
+# Chargement des fichiers depuis Datalake
+df_in_conso_quot_brute_regionale = pd.read_csv(datalake + 'consommation-quotidienne-brute-regionale.csv', usecols=['Date','Heure','Code INSEE région','Consommation brute électricité (MW) - RTE'], sep=';')
+# Renommmage des colonnes
+df_out_conso_quot_region = df_in_conso_quot_brute_regionale
+df_out_conso_quot_region.columns = ['Date', 'Heure', 'Code_region', 'Conso_electrique_brute_MWh']
+# Enregistrement du fichier dans Warehouse_CSV
+df_out_conso_quot_region.to_csv(warehouse_csv + 'conso_quot_region.csv', sep=';', index=False)
+# Confirmation de traitement
+print("Traitement vers conso_quot_region.csv : OK")
+
+
+
+# Traitement vers conso_annuelle_type_region.csv
+# Chargement des fichiers depuis Datalake
+dtype = {
+    'Année': int,
+    'Consommation Agriculture (MWh)': float,
+    'Nombre de points Agriculture': int,
+    'Consommation Industrie (MWh)': float,
+    'Nombre de points Industrie': int,
+    'Consommation Tertiaire  (MWh)': float,
+    'Nombre de points Tertiaire': int,
+    'Consommation Résidentiel  (MWh)': float,
+    'Nombre de points Résidentiel': int,
+    'Code Commune': str,
+    'Code Département': str,
+    'Code Région': str,
+}
+df_in_conso_annuelle_secteur = pd.read_csv(datalake + 'conso-elec-gaz-annuelle-par-secteur-dactivite-agregee-commune.csv', usecols=dtype.keys(), dtype=dtype, sep=';')
+# Renommmage des colonnes
+df_out_conso_annuelle_type_region = df_in_conso_annuelle_secteur
+df_out_conso_annuelle_type_region.columns = ['Annee','Conso_agriculture_MWh', 'Nb_points_agriculture', 'Conso_industrie_MWh', 'Nb_points_industrie','Conso_tertiaire_MWh', 'Nb_points_tertiaire', 'Conso_residentiel_MWh', 'Nb_points_residentiel', 'Code_commune', 'Code_departement', 'Code_region']
+# Réorganiser les colonnes dans le DataFrame
+df_out_conso_annuelle_type_region = df_out_conso_annuelle_type_region.reindex(columns=['Annee', 'Code_region', 'Code_departement', 'Code_commune', 'Conso_agriculture_MWh', 'Nb_points_agriculture', 'Conso_industrie_MWh', 'Nb_points_industrie','Conso_tertiaire_MWh', 'Nb_points_tertiaire', 'Conso_residentiel_MWh', 'Nb_points_residentiel'])
+# Enregistrement du fichier dans Warehouse_CSV
+df_out_conso_annuelle_type_region.to_csv(warehouse_csv + 'conso_annuelle_type_region.csv', sep=';', index=False)
+# Confirmation de traitement
+print("Traitement vers conso_annuelle_type_region.csv : OK")
+
+
+
+# Traitement vers temperature-quotidienne-regionale.csv
+# Chargement des fichiers depuis Datalake
+df_in_temp_quotidienne_regionale = pd.read_csv(datalake + 'temperature-quotidienne-regionale.csv', usecols=['Date', 'Code INSEE région', 'TMin (°C)', 'TMax (°C)', 'TMoy (°C)'], sep=';')
+# Renommmage des colonnes
+df_out_temp_quot_region = df_in_temp_quotidienne_regionale
+df_out_temp_quot_region.columns = ['Date', 'Code_region', 'TMin','TMax','TMoy']
+# Enregistrement du fichier dans Warehouse_CSV
+df_out_temp_quot_region.to_csv(warehouse_csv + 'temp_quot_region.csv', sep=';', index=False)
+# Confirmation de traitement
+print("Traitement vers temp_quot_region.csv : OK")
+
+
+
+# Traitement vers import-exports.csv
+# Chargement des fichiers depuis Datalake
+df_in_import_exports_commerciaux = pd.read_csv(datalake + 'imports-exports-commerciaux.csv', usecols=['Date', "Tranche horaire du programme d'échange", 'FR vers GB (MWh)', 'GB vers FR (MWh)', 'FR vers CWE (MWh)', 'CWE vers FR (MWh)', 'FR vers CH (MWh)', 'CH vers FR (MWh)', 'FR vers IT (MWh)', 'IT vers FR (MWh)', 'FR vers ES (MWh)', 'ES vers FR (MWh)', 'Export France (MWh)', 'Import France (MWh)'], sep=';')
+# Agrégation par date
+df_out_imports_exports = df_in_import_exports_commerciaux.groupby('Date').sum()
+df_out_imports_exports = df_out_imports_exports.reset_index()
+df_out_imports_exports = df_out_imports_exports.drop("Tranche horaire du programme d'échange", axis=1)
+# Renommmage des colonnes
+df_out_imports_exports.columns = ['Date', 'FR_vers_GB__MWh', 'GB_vers_FR__MWh', 'FR_vers_CWE__MWh', 'CWE_vers_FR__MWh', 'FR_vers_CH__MWh', 'CH_vers_FR__MWh', 'FR_vers_IT__MWh','IT_vers_FR__MWh', 'FR_vers_ES__MWh','ES_vers_FR__MWh', 'Export_France__MWh', 'Import_France__MWh']
+# Enregistrement du fichier dans Warehouse_CSV
+df_out_imports_exports.to_csv(warehouse_csv + 'imports_exports.csv', sep=';', index=False)
+# Confirmation de traitement
+print("Traitement vers imports_exports.csv : OK")
+
+
+
+# Traitement vers injection_quot_region.csv
+# Chargement des fichiers depuis Datalake
+df_in_injections_regionales_quotidiennes = pd.read_csv(datalake + 'injections-regionales-quotidiennes-consolidees-rpt.csv', usecols=['Date', 'Code INSEE région', 'Filière', 'Energie journalière (MWh)'], sep=';')
+# Renommmage des colonnes
+df_out_injection_quot_region = df_in_injections_regionales_quotidiennes
+df_out_injection_quot_region.columns = ['Date', 'Code_region', 'Filiere', 'Injection_quot']
+# Enregistrement du fichier dans Warehouse_CSV
+df_out_injection_quot_region.to_csv(warehouse_csv + 'injection_quot_region.csv', sep=';', index=False)
+# Confirmation de traitement
+print("Traitement vers injection_quot_region.csv : OK")
+
+
+# Confirmation de fin de tous les traitements
+print("\n *** Fin du chargement des fichiers du Datalake vers Warehouse_CSV *** \n")


### PR DESCRIPTION
Corrections sur scripts 01 et 02 (ETL) : 
Ordre des colonnes sur conso annuelle par type de clients
Chemin du fichier de config
Renommage des fichiers pour appel plus simple